### PR TITLE
Update service_times.md

### DIFF
--- a/sections/service_times.md
+++ b/sections/service_times.md
@@ -76,7 +76,7 @@ If a service time is associated with an Event, the API will return that Event da
     "active": true,
     "created_at": "2012-01-25T00:14:02Z",
     "updated_at": "2013-03-04T02:19:53Z"
-  }
+  },
   "event": null
 }]
 ```


### PR DESCRIPTION
Missing a comma on the line above event in the Get service times example JSON. This was making the syntax highlighting output for the markdown show a red square.